### PR TITLE
Header links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,5 @@ exclude:
 - README.md
 - CONTRIBUTING.md
 - LICENSE.md
+redcarpet:
+  extensions: ["with_toc_data"]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,11 @@
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css'>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"> </script>
+
+    <!-- header links CSS -->
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="/css/header-links.css" type="text/css" media="screen" />
+
   </head>
   <body>
 
@@ -55,6 +60,22 @@
     </script>
     <!-- Google Analytics end -->
     <script src="/js/default.js" type="text/javascript"></script>
+
+
+    <!-- header links -->
+    <script>
+      $(function() {
+        return $("h2, h3, h4, h5, h6").each(function(i, el) {
+          var $el, icon, id;
+          $el = $(el);
+          id = $el.attr('id');
+          icon = '<i class="fa fa-link"></i>';
+          if (id) {
+            return $el.prepend($("<a />").addClass("header-link").attr("href", "#" + id).html(icon));
+          }
+        });
+      });
+    </script>
 
   </body>
 </html>

--- a/_posts/01-01-09-howdoi.md
+++ b/_posts/01-01-09-howdoi.md
@@ -12,7 +12,7 @@ Settings are represented as behaviors in Light Table. To modify your user behavi
 
 All settings in Light Table work this way and behaviors give you the ability to fundamentally change the functionality of Light Table.
 
-<h3 id="configure-behaviors">Configure behaviors</h3>
+###Configure behaviors
 
 To add a behavior to your `user.behaviors` file, add a vector in the format `[:TAG :COMMAND :ARG1 :ARG2 ...]` e.g. `[:editor :lt.objs.editor/no-wrap]`. If a command takes arguments append them after the command e.g. `[:app :lt.objs.app/set-default-zoom-level -0.5]`. Behaviors that are set by default can be subtracted/removed by prefixing the command with '-'  e.g. `[:editor :-lt.objs.editor/no-wrap]`.
 
@@ -30,7 +30,7 @@ Within an editor, eval a single "block" (or form if you're used to LISP) is boun
 
 Keybindings are defined in .keymap files in Light Table. To open the user keymap, execute the `Settings: User keymap` command. To see the default keybindings you can execute the `Settings: Default keymap` command. Keys are bound based on context (tag), which allows you to create contextual command schemes.
 
-<h3 id="configure-keybindings">Configure keybindings</h3>
+###Configure keybindings
 
 To add a keybinding to your `user.keymap` file, add a vector in the format `[:TAG "KEYBINDING" :COMMAND]` e.g. `[:editor "alt-w" :editor.watch.watch-selection]`. If a command takes arguments wrap the command and its arguments in a parentheses e.g. `[:editor "alt-(" (:paredit.select.parent "(")]`. Keybindings that are set by default can be subtracted/removed by prefixing the key with '-'  e.g. `[:app "-ctrl-shift-d" :docs.search.show]`.
 
@@ -74,7 +74,7 @@ The version `X.X.X` refers to the latest lein-light-nrepl version:
 
 [![Clojars Project](http://clojars.org/lein-light-nrepl/latest-version.svg)](http://clojars.org/lein-light-nrepl)
 
-<h3 id="eval-clojurescript">Eval ClojureScript</h3>
+###Eval ClojureScript
 
 You can eval ClojureScript in a browser or within Light Table's UI itself. To eval in a browser:
 
@@ -146,7 +146,7 @@ You can use the environment variable `LTHOME` to tell the command line scripts w
 
 Use the `App: Light Table version` command from the command tab.
 
-<h3 id="plugins-directory">Plugins directory</h3>
+###Plugins directory
 
 The plugins directory varies depending on the platform:
 
@@ -156,7 +156,7 @@ The plugins directory varies depending on the platform:
 
 Alternatively, you can see your location from running the command `App: Light Table version`.
 
-<h3 id="user-plugin">User plugin</h3>
+###User plugin
 
 Your complete configuration, including plugins you've installed, is stored in a User plugin. Since the User plugin is just a directory, you can share it by putting it under revision control e.g. git and uploading it to a service like Github. To explore it, add it to your workspace with the command `Settings: Add User plugin to workspace`. Any custom keybindings and behaviors are added to `user.keymap` and `user.behaviors`. To write commands, behaviors and more, see `src/lt/plugins/user.cljs`. To open your `user.cljs` at anytime use the command `Settings: User script`. Inside the default `user.cljs` is an example command and behavior. If you're upgrading Light Table, you will need to add two behaviors to `user.behaviors` in order for the examples to work:
 
@@ -168,11 +168,11 @@ Your complete configuration, including plugins you've installed, is stored in a 
 Run the command `User: Say Hello` to see your own command!
 
 
-<h3 id="write-a-plugin">Write a plugin</h3>
+###Write a plugin
 
 Plugins are a great way to share your Light Table enhancement with the community. The recommended way to generate one is with `lein new lt-plugin my-plugin --to-dir MyPlugin`. Make sure to run that it in [your plugin directory](#plugins-directory). Add the generated plugin to your workspace and open the generated `.cljs` file. With your [LT UI connection set up](#eval-clojurescript), eval the file with `Cmd-Shift Enter`. Now try your new plugin command `Say Hello`! For more about writing plugins, see [this wiki page](https://github.com/LightTable/LightTable/wiki/For-Developers#creating-a-plugin).
 
-<h3 id="submit-a-plugin">Submit a plugin</h3>
+###Submit a plugin
 
 If it's your first time submitting a plugin, make sure you have a valid `plugin.edn`. Fill out the keys as follows:
 

--- a/css/header-links.css
+++ b/css/header-links.css
@@ -1,0 +1,17 @@
+.header-link {
+  position: absolute;
+  left: 0.5em;
+  opacity: 0;
+
+  -webkit-transition: opacity 0.2s ease-in-out 0.1s;
+  -moz-transition: opacity 0.2s ease-in-out 0.1s;
+  -ms-transition: opacity 0.2s ease-in-out 0.1s;
+}
+
+h2:hover .header-link,
+h3:hover .header-link,
+h4:hover .header-link,
+h5:hover .header-link,
+h6:hover .header-link {
+  opacity: 1;
+}


### PR DESCRIPTION
Patch to resolve https://github.com/LightTable/docs.lighttable.com/issues/4

Uses some ideas from: http://ben.balter.com/2014/03/13/pages-anchor-links/ and http://milanaryal.com/2015/adding-hover-anchor-links-to-header-on-github-pages-using-jekyll/

Basically it configures redcarpet to set ids on headings then adds a bit of js to insert anchors. Links with font-awesome icons appear on hover over so that you may copy a link. I've removed the explicit ids from the howdoi markdown file to avoid confusion.

Adding the whole of font-awesome for a single icon might be overkill, perhaps a base64 encoded icon would suffice. I'm happy to submit another PR if that would be preferred.
